### PR TITLE
Initial implementation of memory gathering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use collector::{Collector, CollectorValue, CollectorErr};
 // TODO: move all the collector function modules into another directory
 //  might make importing easier, see mod.rs / module docs
 mod cpu;
+mod memory;
 
 // TODO: rename this
 struct PlatformData {
@@ -18,6 +19,15 @@ struct PlatformData {
 // TODO: This also needed a better name than "platform"
 const PLATFORM: &'static [PlatformData] = &[
     PlatformData {tag: "cpu.cores", func: cpu::get_cores},
+    PlatformData {tag: "mem.total", func: memory::get_mem_total},
+    PlatformData {tag: "mem.used", func: memory::get_mem_used},
+    PlatformData {tag: "mem.free", func: memory::get_mem_free},
+    PlatformData {tag: "mem.shared", func: memory::get_mem_shared},
+    PlatformData {tag: "mem.buff/cache", func: memory::get_mem_buff_and_cache},
+    PlatformData {tag: "mem.available", func: memory::get_mem_available},
+    PlatformData {tag: "swap.total", func: memory::get_swap_total},
+    PlatformData {tag: "swap.used", func: memory::get_swap_used},
+    PlatformData {tag: "swap.free", func: memory::get_swap_free},
 ];
 
 fn main() {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 IBM Corp.
+
+use crate::collector::*;
+use regex::Regex;
+
+// add -h to get human readable sizes, else in bytes
+const MEM_COMMAND: &'static str = "free";
+
+
+pub fn get_mem_total(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
+    let re = Regex::new(r"\s+Mem:\s+(\d+)").unwrap();
+    let out = col.run_command(MEM_COMMAND);
+
+    let output = String::from_utf8(out.stdout).unwrap();
+    let caps = re.captures(&output).unwrap();
+
+    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+}
+
+pub fn get_mem_used(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
+    let re = Regex::new(r"\s+Mem:\s+\d+\s+(\d+)").unwrap();
+    let out = col.run_command(MEM_COMMAND);
+
+    let output = String::from_utf8(out.stdout).unwrap();
+    let caps = re.captures(&output).unwrap();
+
+    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+}
+
+pub fn get_mem_free(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
+    let re = Regex::new(r"\s+Mem:\s+(?:\d+\s+){2}(\d+)").unwrap();
+    let out = col.run_command(MEM_COMMAND);
+
+    let output = String::from_utf8(out.stdout).unwrap();
+    let caps = re.captures(&output).unwrap();
+
+    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+}
+
+pub fn get_mem_shared(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
+    let re = Regex::new(r"\s+Mem:\s+(?:\d+\s+){3}(\d+)").unwrap();
+    let out = col.run_command(MEM_COMMAND);
+
+    let output = String::from_utf8(out.stdout).unwrap();
+    let caps = re.captures(&output).unwrap();
+
+    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+}
+
+pub fn get_mem_buff_and_cache(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
+    let re = Regex::new(r"\s+Mem:\s+(?:\d+\s+){4}(\d+)").unwrap();
+    let out = col.run_command(MEM_COMMAND);
+
+    let output = String::from_utf8(out.stdout).unwrap();
+    let caps = re.captures(&output).unwrap();
+
+    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+}
+
+pub fn get_mem_available(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
+    let re = Regex::new(r"\s+Mem:\s+(?:\d+\s+){5}(\d+)").unwrap();
+    let out = col.run_command(MEM_COMMAND);
+
+    let output = String::from_utf8(out.stdout).unwrap();
+    let caps = re.captures(&output).unwrap();
+
+    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+}
+
+// Do similar logic for swap values
+
+pub fn get_swap_total(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
+    let re = Regex::new(r"\s+Swap:\s+(\d+)").unwrap();
+    let out = col.run_command(MEM_COMMAND);
+
+    let output = String::from_utf8(out.stdout).unwrap();
+    let caps = re.captures(&output).unwrap();
+
+    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+}
+
+pub fn get_swap_used(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
+    let re = Regex::new(r"\s+Swap:\s+\d+\s+(\d+)").unwrap();
+    let out = col.run_command(MEM_COMMAND);
+
+    let output = String::from_utf8(out.stdout).unwrap();
+    let caps = re.captures(&output).unwrap();
+
+    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+}
+
+pub fn get_swap_free(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
+    let re = Regex::new(r"\s+Swap:\s+(?:\d+\s+){2}(\d+)").unwrap();
+    let out = col.run_command(MEM_COMMAND);
+
+    let output = String::from_utf8(out.stdout).unwrap();
+    let caps = re.captures(&output).unwrap();
+
+    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+}


### PR DESCRIPTION
Related to issue #6 
Initial work for adding machine memory data to the data collector. It uses the linux command `free` to record the number of free, used and total memory in bytes. Moving forward we may want to represent this in a more human readable unit like gigabytes but for now we store this data in bytes until we know what we want to do with it. 