### PR TITLE
Add generic get regex function

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::process::Command;
 use std::process::Output;
-
+use regex::Regex;
 use serde_json;
 
 pub type CollectorErr = Box<dyn std::error::Error>;
@@ -49,6 +49,19 @@ impl Collector {
 
         self.raw.insert(String::from(command), output);
         self.raw.get(command).unwrap().clone()
+    }
+
+    // returns a string representation of the first capture group of the regex
+    pub fn get_regex_from_command(&mut self, command: &str, regex: &str) -> Option<String> {
+        let re = Regex::new(regex).unwrap();
+        let out = self.run_command(command);
+        let output = String::from_utf8(out.stdout).unwrap();
+        let cap = re.captures(&output).unwrap();
+        if cap.len() < 2 {
+            None
+        } else {
+            Some(String::from(cap.get(1).unwrap().as_str()).clone())
+        }
     }
 
     pub fn add_data(&mut self, tag: String, data: CollectorValue) {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3,6 +3,6 @@
 use crate::collector::*;
 
 pub fn get_cores(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command("lscpu", r"\s+Core\(s\) per socket:\s+(\d+)")?;
+    let captures = col.parse_from_command("lscpu", r"\s+Core\(s\) per socket:\s+(\d+)", OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,19 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 IBM Corp.
-
 use crate::collector::*;
-use regex::Regex;
 
 pub fn get_cores(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    // TODO: There is a lot of boilerplate for this, can we factor this out into a simpler function?
-    let re = Regex::new(r"\s+Core\(s\) per socket:\s+(\d+)").unwrap();
-
-    let out = col.run_command("lscpu");
-
-    // TODO: lot of panicky unwraps in here, we should make this more fault-tolerant
-    let output = String::from_utf8(out.stdout).unwrap();
-    let caps = re.captures(&output).unwrap();
-
-    // TODO: maybe not assume the match worked correctly
-    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+    match col.get_regex_from_command("lscpu", r"\s+Core\(s\) per socket:\s+(\d+)") {
+        None => Err("Failed to find regex capture".into()),
+        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
+    }
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3,8 +3,6 @@
 use crate::collector::*;
 
 pub fn get_cores(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    match col.get_regex_from_command("lscpu", r"\s+Core\(s\) per socket:\s+(\d+)") {
-        None => Err("Failed to find regex capture".into()),
-        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
-    }
+    let captures = col.parse_from_command("lscpu", r"\s+Core\(s\) per socket:\s+(\d+)")?;
+    Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -8,66 +8,48 @@ const MEM_COMMAND: &'static str = "free";
 
 
 pub fn get_mem_total(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    match col.get_regex_from_command(MEM_COMMAND, r"\s+Mem:\s+(\d+)") {
-        None => Err("Failed to find regex capture".into()),
-        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
-    }
+    let captures = col.parse_from_command(MEM_COMMAND, r"\s+Mem:\s+(\d+)")?;
+    Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_used(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    match col.get_regex_from_command(MEM_COMMAND,r"\s+Mem:\s+\d+\s+(\d+)") {
-        None => Err("Failed to find regex capture".into()),
-        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
-    }
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+\d+\s+(\d+)")?;
+    Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_free(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    match col.get_regex_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){2}(\d+)") {
-        None => Err("Failed to find regex capture".into()),
-        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
-    }
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){2}(\d+)")?;
+    Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_shared(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    match col.get_regex_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){3}(\d+)") {
-        None => Err("Failed to find regex capture".into()),
-        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
-    }
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){3}(\d+)")?;
+    Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_buff_and_cache(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    match col.get_regex_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){4}(\d+)") {
-        None => Err("Failed to find regex capture".into()),
-        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
-    }
+    let captures = col.parse_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){4}(\d+)")?;
+    Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_available(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    match col.get_regex_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){5}(\d+)") {
-        None => Err("Failed to find regex capture".into()),
-        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
-    }
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){5}(\d+)")?;
+    Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 // Do similar logic for swap values
 
 pub fn get_swap_total(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    match col.get_regex_from_command(MEM_COMMAND, r"\s+Swap:\s+(\d+)") {
-        None => Err("Failed to find regex capture".into()),
-        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
-    }
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+(\d+)")?;
+    Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_swap_used(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    match col.get_regex_from_command(MEM_COMMAND, r"\s+Swap:\s+\d+\s+(\d+)") {
-        None => Err("Failed to find regex capture".into()),
-        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
-    }
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+\d+\s+(\d+)")?;
+    Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_swap_free(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    match col.get_regex_from_command(MEM_COMMAND, r"\s+Swap:\s+(?:\d+\s+){2}(\d+)") {
-        None => Err("Failed to find regex capture".into()),
-        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
-    }
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+(?:\d+\s+){2}(\d+)")?;
+    Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -2,100 +2,72 @@
 // Copyright 2021 IBM Corp.
 
 use crate::collector::*;
-use regex::Regex;
 
 // add -h to get human readable sizes, else in bytes
 const MEM_COMMAND: &'static str = "free";
 
 
 pub fn get_mem_total(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let re = Regex::new(r"\s+Mem:\s+(\d+)").unwrap();
-    let out = col.run_command(MEM_COMMAND);
-
-    let output = String::from_utf8(out.stdout).unwrap();
-    let caps = re.captures(&output).unwrap();
-
-    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+    match col.get_regex_from_command(MEM_COMMAND, r"\s+Mem:\s+(\d+)") {
+        None => Err("Failed to find regex capture".into()),
+        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
+    }
 }
 
 pub fn get_mem_used(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let re = Regex::new(r"\s+Mem:\s+\d+\s+(\d+)").unwrap();
-    let out = col.run_command(MEM_COMMAND);
-
-    let output = String::from_utf8(out.stdout).unwrap();
-    let caps = re.captures(&output).unwrap();
-
-    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+    match col.get_regex_from_command(MEM_COMMAND,r"\s+Mem:\s+\d+\s+(\d+)") {
+        None => Err("Failed to find regex capture".into()),
+        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
+    }
 }
 
 pub fn get_mem_free(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let re = Regex::new(r"\s+Mem:\s+(?:\d+\s+){2}(\d+)").unwrap();
-    let out = col.run_command(MEM_COMMAND);
-
-    let output = String::from_utf8(out.stdout).unwrap();
-    let caps = re.captures(&output).unwrap();
-
-    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+    match col.get_regex_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){2}(\d+)") {
+        None => Err("Failed to find regex capture".into()),
+        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
+    }
 }
 
 pub fn get_mem_shared(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let re = Regex::new(r"\s+Mem:\s+(?:\d+\s+){3}(\d+)").unwrap();
-    let out = col.run_command(MEM_COMMAND);
-
-    let output = String::from_utf8(out.stdout).unwrap();
-    let caps = re.captures(&output).unwrap();
-
-    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+    match col.get_regex_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){3}(\d+)") {
+        None => Err("Failed to find regex capture".into()),
+        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
+    }
 }
 
 pub fn get_mem_buff_and_cache(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let re = Regex::new(r"\s+Mem:\s+(?:\d+\s+){4}(\d+)").unwrap();
-    let out = col.run_command(MEM_COMMAND);
-
-    let output = String::from_utf8(out.stdout).unwrap();
-    let caps = re.captures(&output).unwrap();
-
-    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+    match col.get_regex_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){4}(\d+)") {
+        None => Err("Failed to find regex capture".into()),
+        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
+    }
 }
 
 pub fn get_mem_available(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let re = Regex::new(r"\s+Mem:\s+(?:\d+\s+){5}(\d+)").unwrap();
-    let out = col.run_command(MEM_COMMAND);
-
-    let output = String::from_utf8(out.stdout).unwrap();
-    let caps = re.captures(&output).unwrap();
-
-    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+    match col.get_regex_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){5}(\d+)") {
+        None => Err("Failed to find regex capture".into()),
+        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
+    }
 }
 
 // Do similar logic for swap values
 
 pub fn get_swap_total(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let re = Regex::new(r"\s+Swap:\s+(\d+)").unwrap();
-    let out = col.run_command(MEM_COMMAND);
-
-    let output = String::from_utf8(out.stdout).unwrap();
-    let caps = re.captures(&output).unwrap();
-
-    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+    match col.get_regex_from_command(MEM_COMMAND, r"\s+Swap:\s+(\d+)") {
+        None => Err("Failed to find regex capture".into()),
+        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
+    }
 }
 
 pub fn get_swap_used(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let re = Regex::new(r"\s+Swap:\s+\d+\s+(\d+)").unwrap();
-    let out = col.run_command(MEM_COMMAND);
-
-    let output = String::from_utf8(out.stdout).unwrap();
-    let caps = re.captures(&output).unwrap();
-
-    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+    match col.get_regex_from_command(MEM_COMMAND, r"\s+Swap:\s+\d+\s+(\d+)") {
+        None => Err("Failed to find regex capture".into()),
+        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
+    }
 }
 
 pub fn get_swap_free(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let re = Regex::new(r"\s+Swap:\s+(?:\d+\s+){2}(\d+)").unwrap();
-    let out = col.run_command(MEM_COMMAND);
-
-    let output = String::from_utf8(out.stdout).unwrap();
-    let caps = re.captures(&output).unwrap();
-
-    Ok(CollectorValue::Integer(caps[1].parse::<i64>().unwrap()))
+    match col.get_regex_from_command(MEM_COMMAND, r"\s+Swap:\s+(?:\d+\s+){2}(\d+)") {
+        None => Err("Failed to find regex capture".into()),
+        Some(capture) => Ok(CollectorValue::Integer(capture.parse::<i64>().unwrap()))
+    }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -8,48 +8,48 @@ const MEM_COMMAND: &'static str = "free";
 
 
 pub fn get_mem_total(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND, r"\s+Mem:\s+(\d+)")?;
+    let captures = col.parse_from_command(MEM_COMMAND, r"\s+Mem:\s+(\d+)", OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_used(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+\d+\s+(\d+)")?;
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+\d+\s+(\d+)", OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_free(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){2}(\d+)")?;
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){2}(\d+)", OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_shared(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){3}(\d+)")?;
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){3}(\d+)", OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_buff_and_cache(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){4}(\d+)")?;
+    let captures = col.parse_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){4}(\d+)", OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_available(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){5}(\d+)")?;
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){5}(\d+)", OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 // Do similar logic for swap values
 
 pub fn get_swap_total(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+(\d+)")?;
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+(\d+)", OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_swap_used(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+\d+\s+(\d+)")?;
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+\d+\s+(\d+)", OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_swap_free(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+(?:\d+\s+){2}(\d+)")?;
+    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+(?:\d+\s+){2}(\d+)", OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }


### PR DESCRIPTION
Dependent on PR #15. I can remove this dependency if it gets held up.

Addresses Issue #4.
This commit adds a function to the `Collector` class for returning a string representation of a regex match when given a command and a regex string. I have demonstrated how this method helps the process of retrieving data by using it in the current data gathering functions.

Let me know if this was not what was intended in the Issue description