### PR TITLE
Collect gcc version

### DIFF
--- a/src/gcc.rs
+++ b/src/gcc.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 IBM Corp.
+
+use crate::collector::*;
+
+const GCC_COMMAND: &'static str = "gcc -v";
+
+pub fn version(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
+    let captures = col.parse_from_command(GCC_COMMAND, r"gcc version (\d.*)", OutputStream::STDERR)?;
+    Ok(CollectorValue::Text(captures[1].to_string()))
+}
+
+pub fn flags(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
+    let captures = col.parse_from_command(GCC_COMMAND, r"Configured with: .*?configure (.*)", OutputStream::STDERR)?;
+    Ok(CollectorValue::Text(captures[1].to_string()))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use collector::{Collector, CollectorValue, CollectorErr};
 //  might make importing easier, see mod.rs / module docs
 mod cpu;
 mod memory;
+mod gcc;
 
 // TODO: rename this
 struct PlatformData {
@@ -28,6 +29,8 @@ const PLATFORM: &'static [PlatformData] = &[
     PlatformData {tag: "swap.total", func: memory::get_swap_total},
     PlatformData {tag: "swap.used", func: memory::get_swap_used},
     PlatformData {tag: "swap.free", func: memory::get_swap_free},
+    PlatformData {tag: "gcc.version", func: gcc::version},
+    PlatformData {tag: "gcc.flags", func: gcc::flags},
 ];
 
 fn main() {


### PR DESCRIPTION
This is for Issue - https://github.com/erichte-ibm/conga/issues/14

It collects gcc version using gcc -v command.

Thanks & Regards,
     - Nayna