### PR TITLE
Add Initial Argument Parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2018"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 regex = "1.5"
+clap = "~2.33"

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -5,6 +5,10 @@ use std::collections::HashMap;
 use std::process::Command;
 use std::process::Output;
 use regex::Regex;
+use std::path::PathBuf;
+use std::fs::File;
+use std::io::Write;
+
 use serde_json;
 
 pub type CollectorErr = Box<dyn std::error::Error>;
@@ -87,7 +91,7 @@ impl Collector {
         Collector{raw: HashMap::new(), data: Vec::new() }
     }
 
-    pub fn print(self) {
+    pub fn to_string(self) -> String {
         let mut map = serde_json::Map::new();
         for d in self.data {
             let val = match d.1 {
@@ -99,6 +103,20 @@ impl Collector {
             map.insert(d.0, val);
         }
 
-        println!("{}", serde_json::to_string(&map).unwrap());
+        serde_json::to_string(&map).unwrap()
     }
-}
+
+    pub fn print(self) {
+        println!("{}", self.to_string());
+    }
+
+    pub fn write_file(self, output: &str) {
+        let output = PathBuf::from(output);
+        let mut file = match File::create(&output) {
+            Err(x) => panic!("couldn't write to {}: {}", output.display(), x),
+            Ok(f) => f,
+        };
+
+        file.write_all(self.to_string().as_bytes()).unwrap();
+    }
+ }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,11 @@ fn main() {
             .long("allow-failures")
             .help("Don't abort if a collector fails")
             .takes_value(false))
+        .arg(Arg::with_name("output")
+            .short("o")
+            .long("output")
+            .help("Output file path to write to")
+            .takes_value(true))
         .get_matches();
 
     // Iterate through each tag:func pair
@@ -71,7 +76,11 @@ fn main() {
         }
     }
 
-    col.print();
+    match matches.value_of("output") {
+        Some(o) => col.write_file(o),
+        None => col.print(),
+    }
+
 }
 
 


### PR DESCRIPTION
Addresses #3 .

This PR adds the `clap` crate to manage argument parsing. Three arguments are currently supported, though only two are currently functional.

---
## New args:
 - `-v` `--verbose`: currently unused, will be used for setting log level for debug purposes
 -  `-f` `--allow-failures`: do not panic if a collector fails, drop the failed tag from the output
 - `-o <file>` `--output <file>`: write the output to the supplied filename instead of to `stdout`
 
---

## Notes:
I am currently not using the `yaml` feature from clap, however that might be a nicer way to manage the arguments if the list grows too long. Chaining a lot of calls can get pretty large, so perhaps that can be moved to another file in the future.

Also, the `--allow-failures` option is potentially contentious: we may want to still record the tag, but either record a null-value, or a error statement instead. Perhaps these can be an option as well.