### PR TITLE
Ensure regex compiles at program compile-time, not runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ edition = "2018"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 regex = "1.5"
+lazy-regex = "2.3"
 clap = "~2.33"

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -61,8 +61,7 @@ impl Collector {
     }
 
     // returns a vector of strings for every match captured from output
-    pub fn parse_from_command(&mut self, command: &str, regex: &str, out_type: OutputStream) -> Result<Vec<String>, CollectorErr> {
-        let re = Regex::new(regex).unwrap();
+    pub fn parse_from_command(&mut self, command: &str, regex: &Regex, out_type: OutputStream) -> Result<Vec<String>, CollectorErr> {
         let out = self.run_command(command);
 
         let output = match out_type {
@@ -70,7 +69,7 @@ impl Collector {
             OutputStream::STDERR => String::from_utf8(out.stderr)?,
         };
 
-        let cap = re.captures(&output);
+        let cap = regex.captures(&output);
         return match cap {
             Some(c) => Ok(
                 c.iter()

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 IBM Corp.
 use crate::collector::*;
+use lazy_regex::regex;
+
 
 pub fn get_cores(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command("lscpu", r"\s+Core\(s\) per socket:\s+(\d+)", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command("lscpu", regex!(r"\s+Core\(s\) per socket:\s+(\d+)"), OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }

--- a/src/gcc.rs
+++ b/src/gcc.rs
@@ -2,15 +2,16 @@
 // Copyright 2021 IBM Corp.
 
 use crate::collector::*;
+use lazy_regex::regex;
 
 const GCC_COMMAND: &'static str = "gcc -v";
 
 pub fn version(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(GCC_COMMAND, r"gcc version (\d.*)", OutputStream::STDERR)?;
+    let captures = col.parse_from_command(GCC_COMMAND, regex!(r"gcc version (\d.*)"), OutputStream::STDERR)?;
     Ok(CollectorValue::Text(captures[1].to_string()))
 }
 
 pub fn flags(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(GCC_COMMAND, r"Configured with: .*?configure (.*)", OutputStream::STDERR)?;
+    let captures = col.parse_from_command(GCC_COMMAND, regex!(r"Configured with: .*?configure (.*)"), OutputStream::STDERR)?;
     Ok(CollectorValue::Text(captures[1].to_string()))
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -2,54 +2,56 @@
 // Copyright 2021 IBM Corp.
 
 use crate::collector::*;
+use lazy_regex::regex;
+
 
 // add -h to get human readable sizes, else in bytes
 const MEM_COMMAND: &'static str = "free";
 
 
 pub fn get_mem_total(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND, r"\s+Mem:\s+(\d+)", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command(MEM_COMMAND, regex!(r"\s+Mem:\s+(\d+)"), OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_used(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+\d+\s+(\d+)", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command(MEM_COMMAND,regex!(r"\s+Mem:\s+\d+\s+(\d+)"), OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_free(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){2}(\d+)", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command(MEM_COMMAND,regex!(r"\s+Mem:\s+(?:\d+\s+){2}(\d+)"), OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_shared(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){3}(\d+)", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command(MEM_COMMAND,regex!(r"\s+Mem:\s+(?:\d+\s+){3}(\d+)"), OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_buff_and_cache(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND, r"\s+Mem:\s+(?:\d+\s+){4}(\d+)", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command(MEM_COMMAND,regex!(r"\s+Mem:\s+(?:\d+\s+){4}(\d+)"), OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_mem_available(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Mem:\s+(?:\d+\s+){5}(\d+)", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command(MEM_COMMAND,regex!(r"\s+Mem:\s+(?:\d+\s+){5}(\d+)"), OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 // Do similar logic for swap values
 
 pub fn get_swap_total(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+(\d+)", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command(MEM_COMMAND,regex!(r"\s+Swap:\s+(\d+)"), OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_swap_used(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+\d+\s+(\d+)", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command(MEM_COMMAND,regex!(r"\s+Swap:\s+\d+\s+(\d+)"), OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }
 
 pub fn get_swap_free(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(MEM_COMMAND,r"\s+Swap:\s+(?:\d+\s+){2}(\d+)", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command(MEM_COMMAND,regex!(r"\s+Swap:\s+(?:\d+\s+){2}(\d+)"), OutputStream::STDOUT)?;
     Ok(CollectorValue::Integer(captures[1].parse::<i64>().unwrap()))
 }

--- a/src/os.rs
+++ b/src/os.rs
@@ -2,17 +2,18 @@
 // Copyright 2021 IBM Corp.
 
 use crate::collector::*;
+use lazy_regex::regex;
 
 const KERNEL_RELEASE_COMMAND: &'static str = "uname --kernel-release";
 const OS_NAME_COMMAND: &'static str = "grep PRETTY_NAME /etc/os-release";
 
 pub fn get_kernel_release(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(KERNEL_RELEASE_COMMAND, r"(.*)", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command(KERNEL_RELEASE_COMMAND, regex!(r"(.*)"), OutputStream::STDOUT)?;
     Ok(CollectorValue::Text(captures[1].to_string()))
 }
 
 
 pub fn get_os_name(col: &mut Collector) -> Result<CollectorValue, CollectorErr> {
-    let captures = col.parse_from_command(OS_NAME_COMMAND, r"PRETTY_NAME=.(.*).", OutputStream::STDOUT)?;
+    let captures = col.parse_from_command(OS_NAME_COMMAND, regex!(r"PRETTY_NAME=.(.*)."), OutputStream::STDOUT)?;
         Ok(CollectorValue::Text(captures[1].to_string()))
 }


### PR DESCRIPTION
A static regex should *never* fail at runtime. The lazy_regex crate provides a `regex!()` macro that builds a Regex struct, and checks its validity at compile-time. This should aid development of new collectors, as these failures can now be spotted at development time, and potentially even show up in-editor.

As a side effect, `parse_from_command` now expects a Regex struct rather than a string. In all cases where a regex is not generated at runtime, this can (and has been) replaced with a call to `regex!()` in the same argument line.

For example, this collector line:

  `let captures = col.parse_from_command("lscpu", r"\s+Core\(s\) per socket:\s+(\d+)", OutputStream::STDOUT)?;`

can be now written as:

  `let captures = col.parse_from_command("lscpu", regex!(r"\s+Core\(s\) per socket:\s+(\d+)"), OutputStream::STDOUT)?;`

At the time of this commit, no collector generates their regex string at runtime, all are static strings.