### PR TITLE
Rework collectors into single vs group, implement CPU vulnerability mitigations collector

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,10 @@ use clap::{App, Arg, crate_version};
 mod cpu;
 mod memory;
 mod gcc;
+mod security;
 
 // TODO: rename this
-struct TagCollector {
+struct SingleCollector {
     tag: &'static str,
     func: fn(&mut Collector) -> Result<CollectorValue, CollectorErr>,
 }
@@ -24,24 +25,25 @@ struct GroupCollector {
 }
 
 enum Tag {
-    Single(TagCollector),
+    Single(SingleCollector),
     Group(GroupCollector),
 }
 
 // TODO: This also needed a better name than "platform"
 const PLATFORM: &'static [Tag] = &[
-    Tag::Single(TagCollector {tag: "cpu.cores", func: cpu::get_cores}),
-    Tag::Single(TagCollector {tag: "mem.total", func: memory::get_mem_total}),
-    Tag::Single(TagCollector {tag: "mem.used", func: memory::get_mem_used}),
-    Tag::Single(TagCollector {tag: "mem.free", func: memory::get_mem_free}),
-    Tag::Single(TagCollector {tag: "mem.shared", func: memory::get_mem_shared}),
-    Tag::Single(TagCollector {tag: "mem.buff/cache", func: memory::get_mem_buff_and_cache}),
-    Tag::Single(TagCollector {tag: "mem.available", func: memory::get_mem_available}),
-    Tag::Single(TagCollector {tag: "swap.total", func: memory::get_swap_total}),
-    Tag::Single(TagCollector {tag: "swap.used", func: memory::get_swap_used}),
-    Tag::Single(TagCollector {tag: "swap.free", func: memory::get_swap_free}),
-    Tag::Single(TagCollector {tag: "gcc.version", func: gcc::version}),
-    Tag::Single(TagCollector {tag: "gcc.flags", func: gcc::flags}),
+    Tag::Single(SingleCollector {tag: "cpu.cores", func: cpu::get_cores}),
+    Tag::Single(SingleCollector {tag: "mem.total", func: memory::get_mem_total}),
+    Tag::Single(SingleCollector {tag: "mem.used", func: memory::get_mem_used}),
+    Tag::Single(SingleCollector {tag: "mem.free", func: memory::get_mem_free}),
+    Tag::Single(SingleCollector {tag: "mem.shared", func: memory::get_mem_shared}),
+    Tag::Single(SingleCollector {tag: "mem.buff/cache", func: memory::get_mem_buff_and_cache}),
+    Tag::Single(SingleCollector {tag: "mem.available", func: memory::get_mem_available}),
+    Tag::Single(SingleCollector {tag: "swap.total", func: memory::get_swap_total}),
+    Tag::Single(SingleCollector {tag: "swap.used", func: memory::get_swap_used}),
+    Tag::Single(SingleCollector {tag: "swap.free", func: memory::get_swap_free}),
+    Tag::Single(SingleCollector {tag: "gcc.version", func: gcc::version}),
+    Tag::Single(SingleCollector {tag: "gcc.flags", func: gcc::flags}),
+    Tag::Group(GroupCollector {tag: "security.vulnerability", func: security::get_vulnerabilities}),
 ];
 
 fn main() {
@@ -99,7 +101,7 @@ fn main() {
 
                 if let Ok(tg) = data {
                     for (tag, d) in tg {
-                        col.add_data(String::from(tag), d)
+                        col.add_data(format!("{}.{}", pd.tag, tag), d)
                     }
                 }
                 else if matches.is_present("allow-failures") {

--- a/src/security.rs
+++ b/src/security.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 IBM Corp.
+use crate::collector::*;
+
+static BASE_DIR: &str = "/sys/devices/system/cpu/vulnerabilities/";
+
+pub fn get_vulnerabilities(_col: &mut Collector) -> Result<Vec<(String, CollectorValue)>, CollectorErr> {
+    let mut ret = Vec::new();
+
+    // TODO: perhaps report missing directory (older kernels?) better here
+    let paths = std::fs::read_dir(BASE_DIR)?;
+
+    for p in paths {
+        // TODO: perhaps skip over errors here in allow-failures mode?
+        let p = p?;
+
+        let out = _col.run_command(format!("cat {}", p.path().display()).as_str());
+
+        let tag = String::from(p.file_name().to_str().unwrap());
+        let value = CollectorValue::Text(String::from_utf8(out.stdout).unwrap().trim().to_string());
+
+        ret.push((tag, value));
+    }
+
+    Ok(ret)
+}


### PR DESCRIPTION
While attempting to implement a collector for CPU vulnerability mitigations, it became clear that not all tags can be determined at runtime. For example, not all kernel versions have the same list of mitigations; the list will likely grow with each new kernel version. Updating conga to support each of these new mitigations is tedious and would require constant maintenance.

Instead, this PR introduces a new concept of `SingleCollector` versus `GroupCollector`.

A `SingleCollector` is exactly as it sounds, it collects a single resulting value, and it is up to the caller to associate the full tag to the resulting value. For example, the `SingleCollector` for fetching number of CPU cores associates the tag `"cpu.cores"` with the result of the function `cpu::get_cores() -> Result<CollectorValue, ...>`. Note that the function returns a single value in its `Result<..>`.

A `GroupCollector` instead expects multiple results, and associates all of the results under one shared tag. The `GroupCollector` function instead returns a `Result<Vec<(String, CollectorValue)>, ...>`. The tuple contains a sub-tag, and the corresponding value.

So taking at look at the CPU vuln mitigations, here is the `GroupCollector`:
```rust
// As defined in the PLATFORM table
  GroupCollector { tag: "security.vulnerability", func: security::get_vulnerabilities }

// Function signature
pub fn get_vulnerabilities(_col: &mut Collector) -> Result<Vec<(String, CollectorValue)>, CollectorErr> 
```
and the output looks something like this:
```
  "security.vulnerability.itlb_multihit": "KVM: Mitigation: VMX disabled",
  "security.vulnerability.l1tf": "Mitigation: PTE Inversion; VMX: conditional cache flushes, SMT vulnerable",
  "security.vulnerability.mds": "Mitigation: Clear CPU buffers; SMT vulnerable",
  "security.vulnerability.meltdown": "Mitigation: PTI",
  "security.vulnerability.spec_store_bypass": "Mitigation: Speculative Store Bypass disabled via prctl",
  "security.vulnerability.spectre_v1": "Mitigation: usercopy/swapgs barriers and __user pointer sanitization",
  "security.vulnerability.spectre_v2": "Mitigation: Retpolines, IBPB: conditional, IBRS_FW, STIBP: conditional, RSB filling",
  "security.vulnerability.srbds": "Mitigation: Microcode",
  "security.vulnerability.tsx_async_abort": "Mitigation: TSX disabled",
 ```
