### PR TITLE
Declare and/or Enforce MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "conga"
 version = "0.1.0"
 authors = ["Eric Richter <erichte@linux.ibm.com>"]
 edition = "2018"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
As determined by running `cargo-msrv`, the Minimum Supported Rust Version (MSRV) of `conga` is `1.46.0`.

We have a couple options for how this can be checked and enforced at compile-time, so we can hopefully avoid running into confusion when certain dependencies decide not to work.

---
### Add a `build.rs` file that fails the build if the compiler is not the expected version

This is probably the most backwards-compatible method for enforcement, but is relatively inflexible for future testing. It will also not prevent dependencies from failing to build since those are built first (I think? not super positive on that).

Perhaps this can at least detect in a dev environment where the rust language server (`rls`) or `rust-analyze` are in use?

### Use `cargo-clippy` or something along those lines

This is a similar approach to the previous option, and slightly more ergonomic. I think it will have the same problems though.

### Add a `rust-version` tag to `Cargo.toml`

This is what this PR at the moment has implemented. Unfortunately, this tag was not added to `cargo` until version `1.56`, and previous versions will only throw a warning at the unknown manifest tag. This is _probably_ our best bet, even though our current actual MSRV is lower than this tag supports.

On the other hand, raising to `1.56` allows us more room to use newer features, though I have not yet explored which might be of value.

